### PR TITLE
Issue 11: SnapMirror clarification

### DIFF
--- a/start/concept-fsx-aws.adoc
+++ b/start/concept-fsx-aws.adoc
@@ -54,3 +54,5 @@ For technical support issues specific to Cloud Manager or micro-services within,
 * Cloud Manager can replicate data only from on-premises or Cloud Volumes ONTAP to FSx for ONTAP.
 
 * At this time iSCSI volumes can be created using the ONTAP CLI, ONTAP API, or Cloud Manager API.
+
+* At this time, SnapMirror replication from FSx for ONTAP is supported using CLI. 


### PR DESCRIPTION
Fixes #11 

At this time, SnapMirror replication from FSx is available using CLI only. I've updated [Limitations](https://docs.netapp.com/us-en/cloud-manager-fsx-ontap/start/concept-fsx-aws.html#limitations) to reflect this. 